### PR TITLE
Add PayPal pop-up lightbox Solves #68

### DIFF
--- a/site/data/share/bg/6-support.yaml
+++ b/site/data/share/bg/6-support.yaml
@@ -1,6 +1,0 @@
-name: Become a Supporter!
-
-# Do not translate below here
-id: support
-titleBefore:
-titleAfter:

--- a/site/data/share/de/6-support.yaml
+++ b/site/data/share/de/6-support.yaml
@@ -1,6 +1,0 @@
-name: Werde Supporter!
-
-# Do not translate below here
-id: support
-titleBefore:
-titleAfter:

--- a/site/data/share/en/6-support.yaml
+++ b/site/data/share/en/6-support.yaml
@@ -1,6 +1,0 @@
-name: Become a Supporter!
-
-# Do not translate below here
-id: support
-titleBefore:
-titleAfter:

--- a/site/data/share/eo/6-support.yaml
+++ b/site/data/share/eo/6-support.yaml
@@ -1,6 +1,0 @@
-name: Fariĝu subtenanto!
-
-# Do not translate below here
-id: support
-titleBefore:
-titleAfter:

--- a/site/data/share/es/6-support.yaml
+++ b/site/data/share/es/6-support.yaml
@@ -1,7 +1,0 @@
-name: Conviértete en Contribuyente !
-
-# Do not translate below here
-id: support
-titleBefore:
-titleAfter:
-

--- a/site/data/share/fr/6-support.yaml
+++ b/site/data/share/fr/6-support.yaml
@@ -1,6 +1,0 @@
-name: Devenez un soutien !
-
-# Do not translate below here
-id: support
-titleBefore:
-titleAfter:

--- a/site/data/share/gj/6-support.yaml
+++ b/site/data/share/gj/6-support.yaml
@@ -1,6 +1,0 @@
-name: સમર્થક બનો!
-
-# Do not translate below here
-id: support
-titleBefore:
-titleAfter:

--- a/site/data/share/hi/6-support.yaml
+++ b/site/data/share/hi/6-support.yaml
@@ -1,6 +1,0 @@
-﻿name: एक समर्थक बनें!
-
-# Do not translate below here
-id: support
-titleBefore:
-titleAfter:

--- a/site/data/share/id/6-support.yaml
+++ b/site/data/share/id/6-support.yaml
@@ -1,6 +1,0 @@
-name: Become a sponsor!
-
-# Do not translate below here
-id: support
-titleBefore:
-titleAfter:

--- a/site/data/share/ms/6-support.yaml
+++ b/site/data/share/ms/6-support.yaml
@@ -1,6 +1,0 @@
-name: Become a sponsor!
-
-# Do not translate below here
-id: support
-titleBefore:
-titleAfter:

--- a/site/data/share/pl/6-support.yaml
+++ b/site/data/share/pl/6-support.yaml
@@ -1,6 +1,0 @@
-name: Wesprzyj nas!
-
-# Do not translate below here
-id: support
-titleBefore:
-titleAfter:

--- a/site/data/share/tl/6-support.yaml
+++ b/site/data/share/tl/6-support.yaml
@@ -1,6 +1,0 @@
-name: Become a Supporter!
-
-# Do not translate below here
-id: support
-titleBefore:
-titleAfter:

--- a/site/data/share/tm/6-support.yaml
+++ b/site/data/share/tm/6-support.yaml
@@ -1,6 +1,0 @@
-name: ஒரு ஆதரவாளர் ஆக!
-
-# Do not translate below here
-id: support
-titleBefore:
-titleAfter:

--- a/site/data/share/tr/6-support.yaml
+++ b/site/data/share/tr/6-support.yaml
@@ -1,6 +1,0 @@
-name: Destekçisi olun!
-
-# Do not translate below here
-id: support
-titleBefore:
-titleAfter:

--- a/site/data/share/vi/6-support.yaml
+++ b/site/data/share/vi/6-support.yaml
@@ -1,6 +1,0 @@
-name: Become a supporter!
-
-# Do not translate below here
-id: support
-titleBefore:
-titleAfter:

--- a/site/data/share/zh_tw/6-support.yaml
+++ b/site/data/share/zh_tw/6-support.yaml
@@ -1,6 +1,0 @@
-name: 支持歐洲自由軟體基金會！
-
-# Do not translate below here
-id: support
-titleBefore:
-titleAfter:

--- a/site/layouts/partials/js.html
+++ b/site/layouts/partials/js.html
@@ -294,6 +294,19 @@ function openPageFromButton(buton,form) {
             break;
     }
 }
+  
+var lightBox = document.getElementById('lightBox');
+
+// LIGHTBOX PayPal open function
+function openLightBox() {
+  lightBox.style.display = "block";
+}
+    
+// LIGHTBOX PayPal close function
+function closeLightBox() {
+  lightBox.style.display = "none";
+}
+  
 Array.prototype.forEach.call(document.querySelectorAll("form.share-buttons"), function(form) {
     onformSubmit(form, openPageFromButton)
 })
@@ -309,3 +322,5 @@ Array.prototype.forEach.call(document.querySelectorAll("form.share-buttons"), fu
 <script type="text/javascript" src="{{ "js/creative.js" | absURL }}"></script>
 <!-- On scroll changing menu -->
 <script type="text/javascript" src="{{ "js/onScrollMenu.js" | absURL }}"></script>
+<!-- PayPal donation Script -->
+<script type="text/javascript" src="{{ "js/donate.js" | absURL }}"></script>

--- a/site/layouts/partials/spread.html
+++ b/site/layouts/partials/spread.html
@@ -15,11 +15,95 @@
                   <p class="text-faded">{{ . | markdownify }}</p>
               {{ end }}
               
+<!-- PayPal donate LightBox-->
+              <div id="lightBox">
+				<span id="close" onclick="closeLightBox()">&#10005;</span>
+                <section class="inline-video">
+				<div class="container">
+					<div class="row">
+						<div class="col-sm-12 col-lg-6">
+							<h1>Donate with Paypal</h1>
+							<br>
+							<form action="https://www.paypal.com/cgi-bin/webscr" method="post">
+                            <!-- Identify your business so that you can collect the payments. -->
+						    <input type="hidden" name="business"
+						        value="office@fossasia.org"><!-- replace with fossasia email -->
+                            <!-- Specify a Donate button. -->
+						    <input id="donate" type="hidden" name="cmd" value="_donations">
+                            <!-- Specify details about the contribution -->
+                            <!-- replace value of the below input items with the values in the code auto generated from paypal -->
+						    <input type="hidden" name="item_name" value="FOSSASIA Friends">
+						    <input type="hidden" name="item_number" value="Supporting FOSSASIA">
+						    <input type="hidden" name="currency_code" value="USD">
+							<button onclick="hider(2,1)" type="submit" class="stripe-button-el"  style="padding:5px 31px"><font color="white"><b> Donation</b></font></button>
+							<button type="button" onclick="hider(2,2)" class="stripe-button-el" style="padding:5px;margin-left:  60px;margin-bottom:  30px" ><font color="white"><b>Regular Supporter</b></font></button></form> 
+							<div id="donation2" class="hide">
+                            <!-- Display the payment button. -->
+							</div>       
+                            <!-- For paypal payments  go the link  https://www.paypal.com/in/cgi-bin/webscr?cmd=_donate-intro-outsideto generate the paypal donate button code -->
+				     <div id="regular2" class="hide">
+							<br>Choose a monthly amount:
+			           <form action="https://www.paypal.com/cgi-bin/webscr" method="post" target="_top">
+							<input type="hidden" name="cmd" value="_xclick">
+							<input type="hidden" name="business" value="office@fossasia.org"><!-- replace with fossasia email -->
+                            <!-- replace value of the below input items with the values in the code auto generated from paypal. Input items may also be subjected to changes due to difference in paypal policies for various countries. -->
+							<input type="hidden" name="lc" value="SG">
+							<input type="hidden" name="item_name" value="Supporter">
+							<input type="hidden" name="button_subtype" value="services">
+							<input type="hidden" name="no_note" value="0">
+							<input type="hidden" name="currency_code" value="USD">
+							<input type="hidden" name="bn" value="PP-BuyNowBF:btn_buynowCC_LG.gif:NonHostedGuest">    
+			 				<input type="hidden" name="on0" value="payment">                               
+                                  <div class="form-inline form-group quater-width">
+                                    <div class="input-group">
+                                      <select name="os0" id="monthlyamount" style="border-radius:5px;width: 200px" class="form-control">
+                                          <option value="monthly">$5/month</option>
+                                          <option value="monthly">$10/month</option>
+                                          <option value="monthly">$25/month</option>
+                                          <option value="monthly">$50/month</option>
+                                          <option value="monthly">$100/month</option>
+                                          <option value="monthly">$250/month</option>
+                                          <option value="monthly">$500/month</option>
+                                        </select>
+                                        <input type="hidden" name="currency_code" value="USD">
+							            <input type="hidden" name="option_select0" value="monthly">
+							            <input type="hidden" name="option_amount0" value="5.00">
+							            <input type="hidden" name="option_select1" value="monthly">
+							            <input type="hidden" name="option_amount1" value="10.00">
+							            <input type="hidden" name="option_select2" value="monthly">
+							            <input type="hidden" name="option_amount2" value="25.00">
+							            <input type="hidden" name="option_select3" value="monthly">
+							            <input type="hidden" name="option_amount3" value="50.00">
+							            <input type="hidden" name="option_select4" value="monthly">
+							            <input type="hidden" name="option_amount4" value="100.00">
+							            <input type="hidden" name="option_select5" value="monthly">
+							            <input type="hidden" name="option_amount5" value="250.00">
+							            <input type="hidden" name="option_select6" value="monthly">
+							            <input type="hidden" name="option_amount6" value="500.00">
+							            <input type="hidden" name="option_index" value="0">
+                                        </div>
+                                  </div>
+							<input type="image" src="https://www.paypalobjects.com/en_GB/i/btn/btn_buynowCC_LG.gif" border="0" name="submit" alt="PayPal – The safer, easier way to pay online!">
+							<img alt="" border="0" src="https://www.paypalobjects.com/en_GB/i/scr/pixel.gif" width="1" height="1">
+						</form>							
+						</div>
+							<p class="lead">
+								The recommended way for donating to us is to join as a regular supporter. You can decide on if you want to pay 10 Euro or more monthly.		
+							</p><p>
+								In case you just want to make a single payment with any amount of your choice, please use the option above.
+					        </p>		
+                      </div>				
+						</div>
+					</div>
+			</section>
+            </div>
+
               <div class="share-buttons">
               {{ .Site.Params.spread.shareTitle }}
 
               {{ $data := index .Site.Data.share .Site.Language.Lang }}
               {{ partial "functions/share_buttons.html" (dict "type" "spread" "defaultSocialText" .Site.Params.spread.defaultSocialText "url" .Site.Params.static.url "lang" ("/" | relLangURL) "data" $data) }}
+              <button class="support" onclick="openLightBox()">Become a supporter!</button>
               </div>
             </div>
         </div>

--- a/site/static/css/buttons-side.css
+++ b/site/static/css/buttons-side.css
@@ -59,9 +59,6 @@ div.sharecolumn .share-buttons.side {
   background-image: url("../img/service-icons/gplus_white.png");
   /* display: none !important; */
 }
-.share-buttons.side .share-support {
-  background-image: url("../img/service-icons/support_red.png");
-}
 
 /* Share pop-up behaviour hacks */
 .share-buttons.side input[type="radio"],

--- a/site/static/css/buttons-spread.css
+++ b/site/static/css/buttons-spread.css
@@ -80,16 +80,6 @@
 .share-buttons.spread .share-gplus:hover {
   background-color: #b12614 !important;
 }
-.share-buttons.spread .share-support {
-  background-color: #d62700;
-  background-image: url("../img/service-icons/support_red.png");
-}
-.share-buttons.spread .share-support:hover {
-  background-color: #842d2d !important;
-}
-.share-buttons.spread .share-support {
-  padding-left: 30px !important;
-}
 
 /* Share pop-up behaviour hacks */
 .share-buttons.spread input[type="radio"],

--- a/site/static/css/custom.css
+++ b/site/static/css/custom.css
@@ -469,3 +469,74 @@ a:hover {
     color: #5a5a5a !important;
 }
 
+/* Lightbox PayPal style */
+#lightBox {
+  background-color: #eee;
+  color: #333;
+  position: fixed;
+  z-index: 1;
+  width: 45%;
+  display: none;
+  transition: 0.3s;
+  display: none;
+  top: 12%;
+  left: 27%;
+  border: 1px solid #333;
+  font-size: 45vm;
+}
+@media (max-width: 1000px) {
+  #lightBox {
+    left: 5%;
+    width: 90%;
+  }
+}
+#close {
+  transition: 0.3s;
+  position: absolute;
+  font-size: 30px;
+  right: 2%;
+  top: 0;
+  cursor: pointer;
+}
+#close:hover {
+  transform: rotate(-90deg);
+}
+.stripe-button-el {
+  background-image: -webkit-linear-gradient(#28a0e5,#015e94);
+  border: none;
+  text-decoration: none;
+  padding: 1px;
+  user-select: none;
+  border-radius: 5px;
+}
+
+/* 'Become a supporter!' button */
+.support {
+  background-color: #d62700;
+  background-image: url("../img/service-icons/support_red.png");
+  display: inline-block;
+  margin: 0px 5px 10px 0;
+  color: #fff;
+  font-weight: 700;
+  font-size: 1em;
+  font-family: "Open Sans","Helvetica Neue",Arial,sans-serif;
+  line-height: normal;
+  text-align: center;
+  text-decoration: none;
+  padding: 7px 7px 7px 20px;
+  min-width: 120px;
+  box-sizing: border-box;
+  display: inline-block;
+  border: none;
+  border-radius: 3px;
+  background-position: left 5px center;
+  background-repeat: no-repeat;
+  background-size: 20px auto;
+  opacity: 0.9;
+  vertical-align: top;
+  line-height: 1.2em;
+  padding-left: 30px !important;
+}
+.support:hover {
+  background-color: #842d2d !important;
+}

--- a/site/static/js/donate.js
+++ b/site/static/js/donate.js
@@ -1,0 +1,116 @@
+function hider(channel,no) {
+  
+    if(channel==1)
+   {
+
+    var x = document.getElementById('donation1')
+    var y = document.getElementById('regular1');
+    if(x.className === 'hide')
+    {
+    if(no==1)
+    {
+     y.className = 'hide';	
+    
+    x.className = 'appear'; 
+    }
+   
+   	}
+   	if(y.className === 'hide')
+   	{
+    if(no==2)
+    { 
+    y.className = 'appear';  
+	x.className = 'hide';  
+ 	
+    }
+   	}
+
+}
+ if(channel==2)
+   {
+
+    var x = document.getElementById('donation2')
+    var y = document.getElementById('regular2');
+    if(x.className === 'hide')
+    {
+    if(no==1)
+    {
+      y.className = 'hide'; 
+    
+    x.className = 'appear'; 
+    }
+   
+   	}
+   	if(y.className === 'hide')
+   	{
+    if(no==2)
+    { 
+   y.className = 'appear';  
+  x.className = 'hide';  
+  
+ 	
+    }
+   	}
+
+}}
+
+/* For stripe payment.
+Two seperate jquery functions are used in stripe payment for donation and regular supporter.
+On clicking the donate button with ids customButton and customButtone respective fumctions 
+will be called*/
+  
+  
+  var handler = StripeCheckout.configure({
+    key: 'pk_test_6pRNASCoBOKtIshFeQd4XMUh',
+    image: 'https://stripe.com/img/documentation/checkout/marketplace.png',
+    token: function (token) {
+        $("#stripeToken").val(token.id);
+        $("#stripeEmail").val(token.email);
+        $("#amount").val($("#amount").val() * 100);
+        $("#myForm").submit();
+    }
+});
+
+$('#customButton').on('click', function (e) {
+    var amount = $("#amount").val() * 100;
+    var displayAmount = parseFloat(Math.floor($("#amount").val() * 100) / 100).toFixed(2);
+    // Open Checkout with further options
+    handler.open({
+        name: 'Demo Site',
+        description: 'Custom amount ($' + displayAmount + ')',
+        amount: amount
+    });
+    e.preventDefault();
+});
+
+// Close Checkout on page navigation
+$(window).on('popstate', function () {
+    handler.close();
+});
+var handler = StripeCheckout.configure({
+    key: 'pk_test_6pRNASCoBOKtIshFeQd4XMUh',
+    image: 'https://stripe.com/img/documentation/checkout/marketplace.png',
+    token: function (token) {
+        $("#stripeTokene").val(token.id);
+        $("#stripeEmaile").val(token.email);
+        $("#amounte").val($("#amount").val() * 100);
+        $("#myForme").submit();
+    }
+});
+
+$('#customButtone').on('click', function (e) {
+    var amount = $("#amounte").val() * 100;
+    var displayAmount = parseFloat(Math.floor($("#amounte").val() * 100) / 100).toFixed(2);
+    // Open Checkout with further options
+    handler.open({
+        name: 'Demo Site',
+        description: 'Custom amount ($' + displayAmount + ')',
+        amount: amount
+    });
+    e.preventDefault();
+});
+
+// Close Checkout on page navigation
+$(window).on('popstate', function () {
+    handler.close();
+});


### PR DESCRIPTION
## Add PayPal pop-up lightbox working like donate section on fossasia.org. This PR solves issue #68 
When you click 'Become a supporter!' button you get pop-up lightbox with PayPal donation like on https://fossasia.org/donate.html. 

I tried to make link preview but after few hours and solid headache I decided that video will be less painful.
Link to preview video: https://drive.google.com/drive/folders/1nYjhHrQSaaHjeuN1kQfyBwAQal9Zg3FV?usp=sharing

Briefly steps I did to get this effect:
1. Deleting share files from all languages in `site/data/share` and deleting all CSS styling this button. I did it to separate this button since all of the share buttons are using function opening URL in new tab which was preventing my button from firing my scripts.
2. Creating exactly same looking button but separately.
3. Creating lightbox pop-up using code delivered by @mariobehling in issue #68 and styling it.
4. Adding file donate.js from fossasia.org repository since code from the 3rd point is also from this repository (thankfully everything works fine).
5. Creating functions to open and close lightbox and adding onclick event to support button.
6. Final fixes and improvements.