### PR TITLE
Hot-linked the .zip containing flyers & logo(s)

### DIFF
--- a/site/config-static.toml
+++ b/site/config-static.toml
@@ -8,7 +8,7 @@ DefaultContentLanguage = "en"
   url         = "https://publiccode.asia"
   slogan_1    = "Public Money"
   slogan_2    = "Public Code"
-  promoLink   = "https://github.com/fossasia/fossasia-artwork/tree/master/PublicCode"
+  promoLink   = "https://github.com/fossasia/fossasia-artwork/blob/master/PublicCode/publiccode.zip?raw=true"
   language    = "Language"
 
 [params.static.meta]


### PR DESCRIPTION
### Fixes #107 

#### Changes Proposed : 

* Download button now, directly downloads a zip file containing all the materials. **(logo's and stickers)**
![image](https://user-images.githubusercontent.com/5800726/34242843-d01aa728-e643-11e7-9bfb-9aec01614c74.png)
## Note :

This PR is interlinked to a another PR named https://github.com/fossasia/fossasia-artwork/pull/4

> #### Both of the PRs should be merged to get it working.