### PR TITLE
#69 Add pl to build.sh

### DIFF
--- a/site/build/build.sh
+++ b/site/build/build.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 # Put all available languages here, except "en". Separated by spaces
-TRANSLATIONS="bg de eo es fr gj hi id ms tl tm tr vi zh_tw"
+TRANSLATIONS="bg de eo es fr pl gj hi id ms tl tm tr vi zh_tw"
 
 basedir="${0%/*}/.."
 cd "$basedir"


### PR DESCRIPTION
**Refers to #69 and #82**  
Some time ago I added Polish translation but Travis check failed so I removed `pl` from `build.sh` and it passed. I thought it's okay but it looks like there's no Polish language so I'm adding this now.