### PR TITLE
Fixes #138: Enhances script deploy.sh

### DIFF
--- a/deploy.sh
+++ b/deploy.sh
@@ -1,14 +1,15 @@
 #!/bin/bash
-set -e # Exit with nonzero exit code if anything fails
+# Exit with nonzero exit code if anything fails
+set -e
 
 SOURCE_BRANCH="master"
 TARGET_BRANCH="gh-pages"
 
 function doCompile {
-  ./site/build/build.sh
+    ./site/build/build.sh
 }
 
-# Pull requests and commits to other branches shouldn't try to deploy, just build to verify
+# Pull requests and commits to other branches shouldn't be deployed but just compilled
 if [ "$TRAVIS_PULL_REQUEST" != "false" -o "$TRAVIS_BRANCH" != "$SOURCE_BRANCH" ]; then
     echo "Skipping deploy; just doing a build."
     doCompile
@@ -28,18 +29,18 @@ cd site/out
 git checkout $TARGET_BRANCH || git checkout --orphan $TARGET_BRANCH
 cd ..
 
-# Clean out existing contents
+# Clean out existing contents and move out
 rm -rf out/*
 cd ..
+
 # Run our compile script
 wget -q https://publiccodeasia.firebaseio.com/subscribers/permission.json?auth=tLtEcFft4F34hknRsT8sPEty0PGOqBMg1n8fLN13 -O signatures.json
 node signatures.js
 mv signatures.json site/data/signatures/.
 doCompile
 cp -r site/public/* site/out
-cp -r site/static/* site/out
 echo publiccode.asia>site/out/CNAME
-ls site/out
+
 # Now let's go have some fun with the cloned repo
 cd site/out/
 git config user.name "Travis CI"
@@ -47,14 +48,15 @@ git config user.email "$COMMIT_AUTHOR_EMAIL"
 
 # If there are no changes to the compiled out (e.g. this is a README update) then just bail.
 if git diff --quiet; then
-    echo "No changes to the output on this push; exiting."
+    echo "No changes detected. Exiting..."
     exit 0
 fi
 
 # Commit the "changes", i.e. the new version.
 # The delta will show diffs between new and old versions.
+# [skip ci] will skip travis ci build for the commit we are about to make
 git add -A .
-git commit -m "Deploy to GitHub Pages: ${SHA}"
+git commit -m "Deploy to GitHub Pages: ${SHA} [skip ci]"
 
 openssl aes-256-cbc -k $pcbuild -in ../../id_rsa.enc -out ../deploy_key -d
 chmod 600 ../deploy_key
@@ -63,4 +65,3 @@ ssh-add ../deploy_key
 
 # Now that we're all set up, we can push.
 git push $SSH_REPO $TARGET_BRANCH
- 


### PR DESCRIPTION
Enhances deploy.sh by properly intending and efractoring it. Removed
useless code like ls on travis ci which was there for testing and
duplicate code. Adds [skip ci[ to the commit that it makes so that
Travis CI won't build it as such functionality is not required.

Fixes #138