### PR TITLE
Fix #157: Changed NavBar display

### DIFF
--- a/site/static/css/creative.css
+++ b/site/static/css/creative.css
@@ -199,7 +199,7 @@ aside {
 
   .navbar-default.affix {
     border-color: rgba(34, 34, 34, 0.05);
-
+    background-color: #fff;
   }
 
   .navbar-default.affix .navbar-header .navbar-brand {

--- a/site/static/css/creative.css
+++ b/site/static/css/creative.css
@@ -199,7 +199,7 @@ aside {
 
   .navbar-default.affix {
     border-color: rgba(34, 34, 34, 0.05);
-    background-color: #fff;
+
   }
 
   .navbar-default.affix .navbar-header .navbar-brand {

--- a/site/static/css/custom.css
+++ b/site/static/css/custom.css
@@ -494,7 +494,7 @@ a:hover {
   border: none;
 }
 .navbar-default {
-  background-color: rgba(90,90,90,0.85) !important;
+  background-color: transparent !important;
   border-bottom: 1px solid #fff !important;
 }
 .changed-nav {

--- a/site/static/css/custom.css
+++ b/site/static/css/custom.css
@@ -494,7 +494,7 @@ a:hover {
   border: none;
 }
 .navbar-default {
-  background-color: transparent !important;
+  background-color: rgba(90,90,90,.85) !important;
   border-bottom: 1px solid #fff !important;
 }
 .changed-nav {

--- a/site/static/css/custom.css
+++ b/site/static/css/custom.css
@@ -494,7 +494,7 @@ a:hover {
   border: none;
 }
 .navbar-default {
-  background-color: transparent !important;
+  background-color: rgba(90,90,90,0.85) !important;
   border-bottom: 1px solid #fff !important;
 }
 .changed-nav {


### PR DESCRIPTION
Changed background-color property at css class .navbar-default (/site/static/css/custom.css) from transparent to rgba(90,90,90,.85).

Now the NavBar isn't transparent and its link are well-seen both on mobile, tablet, desktop etc.

![01](https://user-images.githubusercontent.com/26047592/47958829-7da5f100-dfb2-11e8-8ac8-c46a61831d99.png)
![02](https://user-images.githubusercontent.com/26047592/47958828-7d0d5a80-dfb2-11e8-8aaa-032dd094e32c.png)


